### PR TITLE
feat: add new config command and streamline flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ After installing Chat With Code, you're just a few steps away from a conversatio
          cwc login \
            --api-key=$API_KEY \
            --endpoint "https://your-endpoint.openai.azure.com/" \
-           --api-version "2023-12-01-preview" \
            --deployment-model "gpt-4-turbo"
          ```
 
@@ -142,7 +141,30 @@ PROMPT="please write me a conventional commit for these changes"
 git diff HEAD | cwc $PROMPT | git commit -e --file -
 ```
 
-## Template Features
+## Configuration
+
+Managing your configuration is simple with the `cwc config` command. This command allows you to view and set configuration options for cwc.
+To view the current configuration, use:
+
+```sh
+cwc config get
+```
+
+To set a configuration option, use:
+
+```sh
+cwc config set key1=value1 key2=value2 ...
+```
+
+For example, to disable the gitignore feature and the git directory exclusion, use:
+
+```sh
+cwc config set useGitignore=false excludeGitDir=false
+```
+
+To reset the configuration to default values use `cwc login` to re-authenticate.
+
+## Templates
 
 ### Overview
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	stdErrors "errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/intility/cwc/pkg/config"
+	"github.com/intility/cwc/pkg/errors"
+	"github.com/intility/cwc/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+func createConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Get or set config variables",
+		Long:  `Get or set config variables`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Usage()
+			if err != nil {
+				return fmt.Errorf("failed to print usage: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.AddCommand(createGetConfigCommand())
+	cmd.AddCommand(createSetConfigCommand())
+
+	return cmd
+}
+
+func createGetConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Print current config",
+		Long:  "Print current config",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadConfig()
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			printConfig(cfg)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func createSetConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set config variables",
+		Long:  "Set config variables",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadConfig()
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			// if no args are given, print the help and exit
+			if len(args) == 0 {
+				err = cmd.Help()
+				if err != nil {
+					return fmt.Errorf("failed to print help: %w", err)
+				}
+
+				return nil
+			}
+
+			err = processKeyValuePairs(cfg, args)
+
+			if err != nil {
+				var suppressedError errors.SuppressedError
+				if ok := stdErrors.As(err, &suppressedError); ok {
+					cmd.SilenceUsage = true
+					cmd.SilenceErrors = true
+				}
+
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func processKeyValuePairs(cfg *config.Config, kvPairs []string) error {
+	// iterate over each argument and process them as key=value pairs
+	argKvSubstrCount := 2
+	for _, arg := range kvPairs {
+		kvPair := strings.SplitN(arg, "=", argKvSubstrCount)
+		if len(kvPair) != argKvSubstrCount {
+			return errors.ArgParseError{Message: fmt.Sprintf("invalid argument format: %s, expected key=value", arg)}
+		}
+
+		key := kvPair[0]
+		value := kvPair[1]
+
+		err := setConfigValue(cfg, key, value)
+		if err != nil {
+			return fmt.Errorf("failed to set config value: %w", err)
+		}
+	}
+
+	err := config.SaveConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	printConfig(cfg)
+
+	return nil
+}
+
+func setConfigValue(cfg *config.Config, key, value string) error {
+	switch key {
+	case "endpoint":
+		cfg.Endpoint = value
+	case "deploymentName":
+		cfg.ModelDeployment = value
+	case "apiKey":
+		cfg.SetAPIKey(value)
+	case "useGitignore":
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return errors.ArgParseError{Message: "invalid boolean value for useGitignore: " + value}
+		}
+
+		cfg.UseGitignore = b
+	case "excludeGitDir":
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return errors.ArgParseError{Message: "invalid boolean value for excludeGitDir: " + value}
+		}
+
+		cfg.ExcludeGitDir = b
+	default:
+		ui.PrintMessage(fmt.Sprintf("Unknown config key: %s\n", key), ui.MessageTypeError)
+
+		validKeys := []string{
+			"endpoint",
+			"deploymentName",
+			"apiKey",
+			"useGitignore",
+			"excludeGitDir",
+		}
+
+		ui.PrintMessage("Valid keys are: "+strings.Join(validKeys, ", "), ui.MessageTypeInfo)
+
+		return errors.SuppressedError{}
+	}
+
+	return nil
+}
+
+func printConfig(cfg *config.Config) {
+	table := [][]string{
+		{"Name", "Value"},
+		{"endpoint", cfg.Endpoint},
+		{"deploymentName", cfg.ModelDeployment},
+		{"apiKey", cfg.APIKey()},
+		{"SEP", ""},
+		{"useGitignore", fmt.Sprintf("%t", cfg.UseGitignore)},
+		{"excludeGitDir", fmt.Sprintf("%t", cfg.ExcludeGitDir)},
+	}
+
+	printTable(table)
+}
+
+func printTable(table [][]string) {
+	columnLengths := calculateColumnLengths(table)
+
+	var lineLength int
+
+	additionalChars := 3 // +3 for 3 additional characters before and after each field: "| %s "
+	for _, c := range columnLengths {
+		lineLength += c + additionalChars // +3 for 3 additional characters before and after each field: "| %s "
+	}
+
+	lineLength++                               // +1 for the last "|" in the line
+	singleLineLength := lineLength - len("++") // -2 because of "+" as first and last character
+
+	for lineIndex, line := range table {
+		if lineIndex == 0 { // table header
+			// lineLength-2 because of "+" as first and last charactr
+			ui.PrintMessage(fmt.Sprintf("+%s+\n", strings.Repeat("-", singleLineLength)), ui.MessageTypeInfo)
+		}
+
+	lineLoop:
+		for rowIndex, val := range line {
+			if val == "SEP" {
+				// lineLength-2 because of "+" as first and last character
+				ui.PrintMessage(fmt.Sprintf("+%s+\n", strings.Repeat("-", singleLineLength)), ui.MessageTypeInfo)
+				break lineLoop
+			}
+
+			ui.PrintMessage(fmt.Sprintf("| %-*s ", columnLengths[rowIndex], val), ui.MessageTypeInfo)
+			if rowIndex == len(line)-1 {
+				ui.PrintMessage("|\n", ui.MessageTypeInfo)
+			}
+		}
+
+		if lineIndex == 0 || lineIndex == len(table)-1 { // table header or last line
+			// lineLength-2 because of "+" as first and last character
+			ui.PrintMessage(fmt.Sprintf("+%s+\n", strings.Repeat("-", singleLineLength)), ui.MessageTypeInfo)
+		}
+	}
+}
+
+func calculateColumnLengths(table [][]string) []int {
+	columnLengths := make([]int, len(table[0]))
+
+	for _, line := range table {
+		for i, val := range line {
+			if len(val) > columnLengths[i] {
+				columnLengths[i] = len(val)
+			}
+		}
+	}
+
+	return columnLengths
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,7 +12,6 @@ import (
 var (
 	apiKeyFlag          string //nolint:gochecknoglobals
 	endpointFlag        string //nolint:gochecknoglobals
-	apiVersionFlag      string //nolint:gochecknoglobals
 	modelDeploymentFlag string //nolint:gochecknoglobals
 )
 
@@ -35,17 +34,12 @@ func createLoginCmd() *cobra.Command {
 				endpointFlag = config.SanitizeInput(ui.ReadUserInput())
 			}
 
-			if apiVersionFlag == "" {
-				ui.PrintMessage("Enter the Azure OpenAI API Version: ", ui.MessageTypeInfo)
-				apiVersionFlag = config.SanitizeInput(ui.ReadUserInput())
-			}
-
 			if modelDeploymentFlag == "" {
 				ui.PrintMessage("Enter the Azure OpenAI Model Deployment: ", ui.MessageTypeInfo)
 				modelDeploymentFlag = config.SanitizeInput(ui.ReadUserInput())
 			}
 
-			cfg := config.NewConfig(endpointFlag, apiVersionFlag, modelDeploymentFlag)
+			cfg := config.NewConfig(endpointFlag, modelDeploymentFlag)
 			cfg.SetAPIKey(apiKeyFlag)
 
 			err := config.SaveConfig(cfg)
@@ -69,7 +63,6 @@ func createLoginCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&apiKeyFlag, "api-key", "k", "", "Azure OpenAI API Key")
 	cmd.Flags().StringVarP(&endpointFlag, "endpoint", "e", "", "Azure OpenAI API Endpoint")
-	cmd.Flags().StringVarP(&apiVersionFlag, "api-version", "v", "", "Azure OpenAI API Version")
 	cmd.Flags().StringVarP(&modelDeploymentFlag, "model-deployment", "m", "", "Azure OpenAI Model Deployment")
 
 	return cmd

--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	stdErrors "errors"
 	"fmt"
 	"os"
 
 	"github.com/intility/cwc/cmd"
+	"github.com/intility/cwc/pkg/errors"
 	"github.com/intility/cwc/pkg/ui"
 )
 
@@ -15,7 +17,12 @@ func main() {
 
 	err := command.Execute()
 	if err != nil {
-		ui.PrintMessage(fmt.Sprintf("Error: %s\n", err), ui.MessageTypeError)
+		// if error is of type suppressedError, do not print error message
+		var suppressedError errors.SuppressedError
+		if ok := stdErrors.As(err, &suppressedError); !ok {
+			ui.PrintMessage(fmt.Sprintf("Error: %s\n", err), ui.MessageTypeError)
+		}
+
 		os.Exit(1)
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -91,3 +91,22 @@ type TemplateNotFoundError struct {
 func (e TemplateNotFoundError) Error() string {
 	return "template not found: " + e.TemplateName
 }
+
+func IsTemplateNotFoundError(err error) bool {
+	var templateNotFoundError TemplateNotFoundError
+	return errors.As(err, &templateNotFoundError)
+}
+
+type SuppressedError struct{}
+
+func (e SuppressedError) Error() string {
+	return "error suppressed"
+}
+
+type ArgParseError struct {
+	Message string
+}
+
+func (e ArgParseError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
This change introduces the concept of configurable settings in the main cwc configuration. The rationale behind this change is to enable more configurable options without polluting the commandline interface with more flags.

The configuration can be managed manually by editing the `cwc.yaml` config file or by using the `cwc config set` command.

- Remove `--api-version` flag as it's now hardcoded The apiVersion config is confusing the end-user where they conflate the azure api version with the openai model version. The azure api version is dictating the capabilities of the API and should therefore be managed by the cwc system and not the end user.
- Add `config` cmd to the root command for managing CWC configurations
- Update `README.md` to include configuration management section
- Refactor `cmd/cwc.go` to remove obsolete flags related to gitignore and git directory exclusion, configuring through `cwc config`
- Modify error handling in `main.go` to suppress certain error messages
- Change config file format from JSON to YAML
- Introduce constants for API version and config file properties
- Improve error types with specific checks for template and suppressed errors
- Amend `login.go` to adapt to the removal of the `--api-version` flag and use the new config structure
- Remove unnecessary error message handling in `config.go` related to unmarshalling config data