### PR TITLE
refactor(cmd): move commands to internal package

### DIFF
--- a/.cwc/templates.yaml
+++ b/.cwc/templates.yaml
@@ -35,3 +35,22 @@ templates:
         only return the message title and body in plain text.
       
       My job depends on your ability to follow these instructions, you can do this!
+  - name: refactor
+    description: A template for refactoring code.
+    systemMessage: |
+      You are an expert programmer specializing in refactoring code.
+      Using the following context you will be able to refactor the code as the user requests.
+      
+      Context:
+      {{ .Context }}
+      
+      Procedure:
+      
+      1. Identify the problematic code.
+      2. Think about refactoring patterns and best practices put forward by Martin Fowler and others.
+      3. Reason about how to apply those patterns to the code.
+      4. Refactor the code.
+      
+      Assume that the user is a senior developer and can understand and discuss the refactoring decisions.
+      Don't make assumptions about the code that are not present in the context.
+      Please defer to the user for any additional information needed to effectively refactor the code.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,7 +63,7 @@ linters-settings:
     sections:
       - standard
       - default
-      - prefix(github.com/emilkje/cwc)
+      - prefix(github.com/intility/cwc)
   depguard:
     rules:
       prevent_unmaintained_packages:

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/intility/cwc/pkg/config"
 	"github.com/intility/cwc/pkg/errors"
 	"github.com/intility/cwc/pkg/ui"
-	"github.com/spf13/cobra"
 )
 
 func createConfigCommand() *cobra.Command {

--- a/cmd/cwc.go
+++ b/cmd/cwc.go
@@ -1,28 +1,16 @@
 package cmd
 
 import (
-	stdErrors "errors"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"strings"
-	tt "text/template"
 
-	"github.com/intility/cwc/pkg/chat"
-	"github.com/intility/cwc/pkg/config"
-	"github.com/intility/cwc/pkg/errors"
-	"github.com/intility/cwc/pkg/filetree"
-	"github.com/intility/cwc/pkg/pathmatcher"
-	"github.com/intility/cwc/pkg/templates"
-	"github.com/intility/cwc/pkg/ui"
-	"github.com/sashabaranov/go-openai"
 	"github.com/spf13/cobra"
+
+	"github.com/intility/cwc/internal/cmd"
 )
 
 const (
-	warnFileSizeThreshold = 100000
-	longDescription       = `The 'cwc' command initiates a new chat session, 
+	longDescription = `The 'cwc' command initiates a new chat session, 
 providing granular control over the inclusion and exclusion of files via regular expression patterns. 
 It allows for specification of paths to include or exclude files from the chat context.
 
@@ -65,34 +53,43 @@ func CreateRootCommand() *cobra.Command {
 	loginCmd := createLoginCmd()
 	logoutCmd := createLogoutCmd()
 
-	cmd := &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:   "cwc [prompt]",
 		Short: "starts a new chat session",
 		Long:  longDescription,
 		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if isPiped(os.Stdin) {
-				return nonInteractive(args, templateFlag, templateVariablesFlag)
+				nic := cmd.NewNonInteractiveCmd(args, templateFlag, templateVariablesFlag)
+
+				err := nic.Run()
+				if err != nil {
+					return fmt.Errorf("error running non-interactive command: %w", err)
+				}
+
+				return nil
 			}
 
-			chatOpts := &chatOptions{
-				includeFlag:           includeFlag,
-				excludeFlag:           excludeFlag,
-				pathsFlag:             pathsFlag,
-				templateFlag:          templateFlag,
-				templateVariablesFlag: templateVariablesFlag,
+			chatOpts := cmd.InteractiveChatOptions{
+				IncludePattern:    includeFlag,
+				ExcludePattern:    excludeFlag,
+				Paths:             pathsFlag,
+				TemplateName:      templateFlag,
+				TemplateVariables: templateVariablesFlag,
 			}
 
-			var prompt string
-			if len(args) > 0 {
-				prompt = args[0]
+			interactiveCmd := cmd.NewInteractiveCmd(args, chatOpts)
+
+			err := interactiveCmd.Run()
+			if err != nil {
+				return fmt.Errorf("error running interactive command: %w", err)
 			}
 
-			return interactiveChat(prompt, chatOpts)
+			return nil
 		},
 	}
 
-	initFlags(cmd, &flags{
+	initFlags(rootCmd, &flags{
 		includeFlag:           &includeFlag,
 		excludeFlag:           &excludeFlag,
 		pathsFlag:             &pathsFlag,
@@ -100,12 +97,12 @@ func CreateRootCommand() *cobra.Command {
 		templateVariablesFlag: &templateVariablesFlag,
 	})
 
-	cmd.AddCommand(loginCmd)
-	cmd.AddCommand(logoutCmd)
-	cmd.AddCommand(createTemplatesCmd())
-	cmd.AddCommand(createConfigCommand())
+	rootCmd.AddCommand(loginCmd)
+	rootCmd.AddCommand(logoutCmd)
+	rootCmd.AddCommand(createTemplatesCmd())
+	rootCmd.AddCommand(createConfigCommand())
 
-	return cmd
+	return rootCmd
 }
 
 type flags struct {
@@ -147,389 +144,4 @@ func isPiped(file *os.File) bool {
 	}
 
 	return (fileInfo.Mode() & os.ModeCharDevice) == 0
-}
-
-func interactiveChat(prompt string, chatOpts *chatOptions) error {
-	// Load configuration
-	cfg, err := config.NewFromConfigFile()
-	if err != nil {
-		return fmt.Errorf("error reading config: %w", err)
-	}
-
-	client := openai.NewClientWithConfig(cfg)
-
-	// Gather context from files
-	files, fileTree, err := gatherAndPrintContext(chatOpts)
-	if err != nil {
-		return err
-	} else if len(files) == 0 { // No files found, terminating or confirming to proceed
-		if !askConfirmation("No files found matching the given criteria.\n", ui.MessageTypeWarning) {
-			return nil
-		}
-	}
-
-	contextStr := createContext(fileTree, files)
-
-	systemMessage, err := createSystemMessage(contextStr, chatOpts.templateFlag, chatOpts.templateVariablesFlag)
-	if err != nil {
-		return fmt.Errorf("error creating system message: %w", err)
-	}
-
-	ui.PrintMessage("Type '/exit' to end the chat.\n", ui.MessageTypeNotice)
-
-	if prompt == "" {
-		prompt = getPromptFromUserOrTemplate(chatOpts.templateFlag)
-	} else {
-		ui.PrintMessage(fmt.Sprintf("👤: %s\n", prompt), ui.MessageTypeInfo)
-	}
-
-	if prompt == "/exit" {
-		return nil
-	}
-
-	handleChat(client, systemMessage, prompt)
-
-	return nil
-}
-
-func getPromptFromUserOrTemplate(templateName string) string {
-	// get default prompt from template
-	var prompt string
-
-	if templateName == "" {
-		ui.PrintMessage("👤: ", ui.MessageTypeInfo)
-		return ui.ReadUserInput()
-	}
-
-	template, err := getTemplate(templateName)
-	if err != nil {
-		var notFoundErr errors.TemplateNotFoundError
-		ok := stdErrors.As(err, &notFoundErr)
-
-		if !ok || (len(templateName) != 0 && templateName != "default") {
-			ui.PrintMessage(err.Error()+"\n", ui.MessageTypeWarning)
-		}
-
-		ui.PrintMessage("👤: ", ui.MessageTypeInfo)
-
-		return ui.ReadUserInput()
-	}
-
-	if template.DefaultPrompt == "" {
-		ui.PrintMessage("👤: ", ui.MessageTypeInfo)
-		prompt = ui.ReadUserInput()
-	} else {
-		prompt = template.DefaultPrompt
-		ui.PrintMessage(fmt.Sprintf("👤: %s\n", prompt), ui.MessageTypeInfo)
-	}
-
-	return prompt
-}
-
-func handleChat(client *openai.Client, systemMessage string, prompt string) {
-	chatInstance := chat.NewChat(client, systemMessage, printMessageChunk)
-	conversation := chatInstance.BeginConversation(prompt)
-
-	for {
-		conversation.WaitMyTurn()
-		ui.PrintMessage("👤: ", ui.MessageTypeInfo)
-
-		userMessage := ui.ReadUserInput()
-
-		if userMessage == "/exit" {
-			break
-		}
-
-		conversation.Reply(userMessage)
-	}
-}
-
-func createContext(fileTree string, files []filetree.File) string {
-	contextStr := "File tree:\n\n"
-	contextStr += "```\n" + fileTree + "```\n\n"
-	contextStr += "File contents:\n\n"
-
-	for _, file := range files {
-		// find extension by splitting on ".". if no extension, use
-		contextStr += fmt.Sprintf("./%s\n```%s\n%s\n```\n\n", file.Path, file.Type, file.Data)
-	}
-
-	return contextStr
-}
-
-// gatherAndPrintContext gathers file context based on provided options and prints it out.
-func gatherAndPrintContext(chatOptions *chatOptions) ([]filetree.File, string, error) {
-	files, rootNode, err := gatherContext(chatOptions)
-	if err != nil {
-		return nil, "", err
-	}
-
-	for _, file := range files {
-		printLargeFileWarning(file)
-	}
-
-	fileTree := filetree.GenerateFileTree(rootNode, "", true)
-
-	ui.PrintMessage("The following files will be used as context:\n", ui.MessageTypeInfo)
-	ui.PrintMessage(fileTree, ui.MessageTypeInfo)
-
-	return files, fileTree, nil
-}
-
-// askConfirmation prompts the user if they want to proceed with no files.
-func askConfirmation(prompt string, messageType ui.MessageType) bool {
-	ui.PrintMessage(prompt, messageType)
-
-	if !ui.AskYesNo("Do you wish to proceed?", false) {
-		ui.PrintMessage("See ya later!", ui.MessageTypeInfo)
-		return false
-	}
-
-	return true
-}
-
-func printLargeFileWarning(file filetree.File) {
-	if len(file.Data) > warnFileSizeThreshold {
-		largeFileMsg := fmt.Sprintf(
-			"warning: %s is very large (%d bytes) and will degrade performance.\n",
-			file.Path, len(file.Data))
-
-		ui.PrintMessage(largeFileMsg, ui.MessageTypeWarning)
-	}
-}
-
-func getTemplate(templateName string) (*templates.Template, error) {
-	if templateName == "" {
-		templateName = "default"
-	}
-
-	var locators []templates.TemplateLocator
-
-	configDir, err := config.GetConfigDir()
-	if err == nil {
-		locators = append(locators, templates.NewYamlFileTemplateLocator(filepath.Join(configDir, "templates.yaml")))
-	}
-
-	locators = append(locators, templates.NewYamlFileTemplateLocator(filepath.Join(".cwc", "templates.yaml")))
-	mergedLocator := templates.NewMergedTemplateLocator(locators...)
-
-	tmpl, err := mergedLocator.GetTemplate(templateName)
-	if err != nil {
-		if errors.IsTemplateNotFoundError(err) {
-			return nil, errors.TemplateNotFoundError{TemplateName: templateName}
-		}
-
-		return nil, fmt.Errorf("error getting template: %w", err)
-	}
-
-	return tmpl, nil
-}
-
-func createSystemMessage(ctx string, templateName string, templateVariables map[string]string) (string, error) {
-	template, err := getTemplate(templateName)
-
-	if templateVariables == nil {
-		templateVariables = make(map[string]string)
-	}
-
-	// if no template found, create a basic template as fallback
-	if errors.IsTemplateNotFoundError(err) {
-		return createBuiltinSystemMessageFromContext(ctx), nil
-	}
-
-	// compile the template.SystemMessage as a go template
-	tmpl, err := tt.New("systemMessage").Parse(template.SystemMessage)
-	if err != nil {
-		return "", fmt.Errorf("error parsing template: %w", err)
-	}
-
-	type valueBag struct {
-		Context   string
-		Variables map[string]string
-	}
-
-	// populate the variables map with default values if not provided
-	for _, v := range template.Variables {
-		if _, ok := templateVariables[v.Name]; !ok {
-			templateVariables[v.Name] = v.DefaultValue
-		}
-	}
-
-	values := valueBag{
-		Context:   ctx,
-		Variables: templateVariables,
-	}
-
-	writer := &strings.Builder{}
-	err = tmpl.Execute(writer, values)
-
-	if err != nil {
-		return "", fmt.Errorf("error executing template: %w", err)
-	}
-
-	return writer.String(), nil
-}
-
-func printMessageChunk(chunk *chat.ConversationChunk) {
-	if chunk.IsInitialChunk {
-		ui.PrintMessage("🤖: ", ui.MessageTypeInfo)
-		return
-	}
-
-	if chunk.IsErrorChunk {
-		ui.PrintMessage(chunk.Content, ui.MessageTypeError)
-	}
-
-	if chunk.IsFinalChunk {
-		ui.PrintMessage("\n", ui.MessageTypeInfo)
-	}
-
-	ui.PrintMessage(chunk.Content, ui.MessageTypeInfo)
-}
-
-func nonInteractive(args []string, templateName string, templateVars map[string]string) error {
-	var prompt string
-
-	template, err := getTemplate(templateName)
-	if err != nil {
-		var templateNotFoundError errors.TemplateNotFoundError
-		if stdErrors.As(err, &templateNotFoundError) {
-			if len(args) == 0 {
-				return &errors.NoPromptProvidedError{Message: "no prompt provided"}
-			}
-		}
-	} else {
-		prompt = template.DefaultPrompt
-	}
-
-	// args takes precedence over template.DefaultPrompt
-	if len(args) > 0 {
-		prompt = args[0]
-	}
-
-	inputBytes, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		return fmt.Errorf("error reading from stdin: %w", err)
-	}
-
-	systemContext := string(inputBytes)
-
-	systemMessage, err := createSystemMessage(systemContext, templateName, templateVars)
-	if err != nil {
-		return fmt.Errorf("error creating system message: %w", err)
-	}
-
-	cfg, err := config.NewFromConfigFile()
-	if err != nil {
-		return fmt.Errorf("error reading config: %w", err)
-	}
-
-	client := openai.NewClientWithConfig(cfg)
-
-	onChunk := func(chunk *chat.ConversationChunk) {
-		ui.PrintMessage(chunk.Content, ui.MessageTypeInfo)
-	}
-	chatInstance := chat.NewChat(client, systemMessage, onChunk)
-	conversation := chatInstance.BeginConversation(prompt)
-
-	conversation.WaitMyTurn()
-
-	return nil
-}
-
-func createBuiltinSystemMessageFromContext(context string) string {
-	var systemMessage strings.Builder
-
-	systemMessage.WriteString("You are a helpful coding assistant. ")
-	systemMessage.WriteString("Below you will find relevant context to answer the user's question.\n\n")
-	systemMessage.WriteString("Context:\n")
-	systemMessage.WriteString(context)
-	systemMessage.WriteString("\n\n")
-	systemMessage.WriteString("Please follow the users instructions, you can do this!")
-
-	return systemMessage.String()
-}
-
-type chatOptions struct {
-	includeFlag           string
-	excludeFlag           string
-	pathsFlag             []string
-	templateFlag          string
-	templateVariablesFlag map[string]string
-}
-
-func gatherContext(opts *chatOptions) ([]filetree.File, *filetree.FileNode, error) {
-	includeFlag := opts.includeFlag
-	excludeFlag := opts.excludeFlag
-	pathsFlag := opts.pathsFlag
-
-	var excludeMatchers []pathmatcher.PathMatcher
-
-	// add exclude flag to excludeMatchers
-	if excludeFlag != "" {
-		excludeMatcher, err := pathmatcher.NewRegexPathMatcher(excludeFlag)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error creating exclude matcher: %w", err)
-		}
-
-		excludeMatchers = append(excludeMatchers, excludeMatcher)
-	}
-
-	excludeMatchersFromConfig, err := excludeMatchersFromConfig()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	excludeMatchers = append(excludeMatchers, excludeMatchersFromConfig...)
-
-	excludeMatcher := pathmatcher.NewCompoundPathMatcher(excludeMatchers...)
-
-	includeMatcher, err := pathmatcher.NewRegexPathMatcher(includeFlag)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating include matcher: %w", err)
-	}
-
-	files, rootNode, err := filetree.GatherFiles(&filetree.FileGatherOptions{
-		IncludeMatcher: includeMatcher,
-		ExcludeMatcher: excludeMatcher,
-		PathScopes:     pathsFlag,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("error gathering files: %w", err)
-	}
-
-	return files, rootNode, nil
-}
-
-func excludeMatchersFromConfig() ([]pathmatcher.PathMatcher, error) {
-	var excludeMatchers []pathmatcher.PathMatcher
-
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return excludeMatchers, fmt.Errorf("error loading config: %w", err)
-	}
-
-	if cfg.UseGitignore {
-		gitignoreMatcher, err := pathmatcher.NewGitignorePathMatcher()
-		if err != nil {
-			if errors.IsGitNotInstalledError(err) {
-				ui.PrintMessage("warning: git not found in PATH, skipping .gitignore\n", ui.MessageTypeWarning)
-			} else {
-				return nil, fmt.Errorf("error creating gitignore matcher: %w", err)
-			}
-		}
-
-		excludeMatchers = append(excludeMatchers, gitignoreMatcher)
-	}
-
-	if cfg.ExcludeGitDir {
-		gitDirMatcher, err := pathmatcher.NewRegexPathMatcher(`^\.git(/|\\)`)
-		if err != nil {
-			return nil, fmt.Errorf("error creating git directory matcher: %w", err)
-		}
-
-		excludeMatchers = append(excludeMatchers, gitDirMatcher)
-	}
-
-	return excludeMatchers, nil
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/intility/cwc/pkg/config"
 	"github.com/intility/cwc/pkg/errors"
 	"github.com/intility/cwc/pkg/ui"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/intility/cwc/pkg/config"
 	"github.com/spf13/cobra"
+
+	"github.com/intility/cwc/pkg/config"
 )
 
 func createLogoutCmd() *cobra.Command {

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -4,10 +4,11 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/intility/cwc/pkg/config"
 	"github.com/intility/cwc/pkg/templates"
 	"github.com/intility/cwc/pkg/ui"
-	"github.com/spf13/cobra"
 )
 
 type Template struct {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	stdErrors "errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	tt "text/template"
+
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/intility/cwc/pkg/config"
+	"github.com/intility/cwc/pkg/errors"
+	"github.com/intility/cwc/pkg/filetree"
+	"github.com/intility/cwc/pkg/pathmatcher"
+	"github.com/intility/cwc/pkg/templates"
+	"github.com/intility/cwc/pkg/ui"
+)
+
+const (
+	warnFileSizeThreshold = 100000
+)
+
+func newClientFromConfig() (*openai.Client, error) {
+	cfg, err := config.NewFromConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("error reading config: %w", err)
+	}
+
+	client := openai.NewClientWithConfig(cfg)
+
+	return client, nil
+}
+
+func determinePrompt(args []string, templateName string) string {
+	var prompt string
+
+	template, err := getTemplate(templateName)
+	if err != nil {
+		var templateNotFoundError errors.TemplateNotFoundError
+		if stdErrors.As(err, &templateNotFoundError) {
+			if len(args) == 0 {
+				return ""
+			}
+		}
+	} else {
+		prompt = template.DefaultPrompt
+	}
+
+	// args takes precedence over template.DefaultPrompt
+	if len(args) > 0 {
+		prompt = args[0]
+	}
+
+	return prompt
+}
+
+func getTemplate(templateName string) (*templates.Template, error) {
+	if templateName == "" {
+		templateName = "default"
+	}
+
+	var locators []templates.TemplateLocator
+
+	configDir, err := config.GetConfigDir()
+	if err == nil {
+		locators = append(locators, templates.NewYamlFileTemplateLocator(filepath.Join(configDir, "templates.yaml")))
+	}
+
+	locators = append(locators, templates.NewYamlFileTemplateLocator(filepath.Join(".cwc", "templates.yaml")))
+	mergedLocator := templates.NewMergedTemplateLocator(locators...)
+
+	tmpl, err := mergedLocator.GetTemplate(templateName)
+	if err != nil {
+		if errors.IsTemplateNotFoundError(err) {
+			return nil, errors.TemplateNotFoundError{TemplateName: templateName}
+		}
+
+		return nil, fmt.Errorf("error getting template: %w", err)
+	}
+
+	return tmpl, nil
+}
+
+func createSystemMessage(ctx string, templateName string, templateVariables map[string]string) (string, error) {
+	template, err := getTemplate(templateName)
+
+	if templateVariables == nil {
+		templateVariables = make(map[string]string)
+	}
+
+	// if no template found, create a basic template as fallback
+	if errors.IsTemplateNotFoundError(err) {
+		return createBuiltinSystemMessageFromContext(ctx), nil
+	}
+
+	// compile the template.SystemMessage as a go template
+	tmpl, err := tt.New("systemMessage").Parse(template.SystemMessage)
+	if err != nil {
+		return "", fmt.Errorf("error parsing template: %w", err)
+	}
+
+	type valueBag struct {
+		Context   string
+		Variables map[string]string
+	}
+
+	// populate the variables map with default values if not provided
+	for _, v := range template.Variables {
+		if _, ok := templateVariables[v.Name]; !ok {
+			templateVariables[v.Name] = v.DefaultValue
+		}
+	}
+
+	values := valueBag{
+		Context:   ctx,
+		Variables: templateVariables,
+	}
+
+	writer := &strings.Builder{}
+	err = tmpl.Execute(writer, values)
+
+	if err != nil {
+		return "", fmt.Errorf("error executing template: %w", err)
+	}
+
+	return writer.String(), nil
+}
+
+func createBuiltinSystemMessageFromContext(context string) string {
+	var systemMessage strings.Builder
+
+	systemMessage.WriteString("You are a helpful coding assistant. ")
+	systemMessage.WriteString("Below you will find relevant context to answer the user's question.\n\n")
+	systemMessage.WriteString("Context:\n")
+	systemMessage.WriteString(context)
+	systemMessage.WriteString("\n\n")
+	systemMessage.WriteString("Please follow the users instructions, you can do this!")
+
+	return systemMessage.String()
+}
+
+// askConfirmation prompts the user if they want to proceed with no files.
+func askConfirmation(prompt string, messageType ui.MessageType) bool {
+	ui.PrintMessage(prompt, messageType)
+
+	if !ui.AskYesNo("Do you wish to proceed?", false) {
+		ui.PrintMessage("See ya later!", ui.MessageTypeInfo)
+		return false
+	}
+
+	return true
+}
+
+func excludeMatchersFromConfig() ([]pathmatcher.PathMatcher, error) {
+	var excludeMatchers []pathmatcher.PathMatcher
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return excludeMatchers, fmt.Errorf("error loading config: %w", err)
+	}
+
+	if cfg.UseGitignore {
+		gitignoreMatcher, err := pathmatcher.NewGitignorePathMatcher()
+		if err != nil {
+			if errors.IsGitNotInstalledError(err) {
+				ui.PrintMessage("warning: git not found in PATH, skipping .gitignore\n", ui.MessageTypeWarning)
+			} else {
+				return nil, fmt.Errorf("error creating gitignore matcher: %w", err)
+			}
+		}
+
+		excludeMatchers = append(excludeMatchers, gitignoreMatcher)
+	}
+
+	if cfg.ExcludeGitDir {
+		gitDirMatcher, err := pathmatcher.NewRegexPathMatcher(`^\.git(/|\\)`)
+		if err != nil {
+			return nil, fmt.Errorf("error creating git directory matcher: %w", err)
+		}
+
+		excludeMatchers = append(excludeMatchers, gitDirMatcher)
+	}
+
+	return excludeMatchers, nil
+}
+
+func printLargeFileWarning(file filetree.File) {
+	if len(file.Data) > warnFileSizeThreshold {
+		largeFileMsg := fmt.Sprintf(
+			"warning: %s is very large (%d bytes) and will degrade performance.\n",
+			file.Path, len(file.Data))
+
+		ui.PrintMessage(largeFileMsg, ui.MessageTypeWarning)
+	}
+}
+
+func createContext(fileTree string, files []filetree.File) string {
+	contextStr := "File tree:\n\n"
+	contextStr += "```\n" + fileTree + "```\n\n"
+	contextStr += "File contents:\n\n"
+
+	for _, file := range files {
+		// find extension by splitting on ".". if no extension, use
+		contextStr += fmt.Sprintf("./%s\n```%s\n%s\n```\n\n", file.Path, file.Type, file.Data)
+	}
+
+	return contextStr
+}

--- a/internal/cmd/interactive.go
+++ b/internal/cmd/interactive.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/intility/cwc/pkg/chat"
+	"github.com/intility/cwc/pkg/filetree"
+	"github.com/intility/cwc/pkg/pathmatcher"
+	"github.com/intility/cwc/pkg/ui"
+)
+
+type InteractiveChatOptions struct {
+	IncludePattern    string
+	ExcludePattern    string
+	Paths             []string
+	TemplateName      string
+	TemplateVariables map[string]string
+}
+
+type InteractiveCmd struct {
+	prompt      string
+	chatOptions InteractiveChatOptions
+}
+
+func NewInteractiveCmd(args []string, chatOptions InteractiveChatOptions) *InteractiveCmd {
+	prompt := determinePrompt(args, chatOptions.TemplateName)
+	return &InteractiveCmd{prompt: prompt, chatOptions: chatOptions}
+}
+
+func (c *InteractiveCmd) Run() error {
+	client, err := newClientFromConfig()
+	if err != nil {
+		return fmt.Errorf("error creating client: %w", err)
+	}
+
+	files, fileTree, err := c.gatherAndPrintContext()
+	if err != nil {
+		return err
+	} else if len(files) == 0 { // No files found, terminating or confirming to proceed
+		if !askConfirmation("No files found matching the given criteria.\n", ui.MessageTypeWarning) {
+			return nil
+		}
+	}
+
+	contextStr := createContext(fileTree, files)
+
+	systemMessage, err := createSystemMessage(contextStr, c.chatOptions.TemplateName, c.chatOptions.TemplateVariables)
+	if err != nil {
+		return fmt.Errorf("error creating system message: %w", err)
+	}
+
+	ui.PrintMessage("Type '/exit' to end the chat.\n", ui.MessageTypeNotice)
+
+	if c.prompt == "" {
+		ui.PrintMessage("👤: ", ui.MessageTypeInfo)
+		c.prompt = ui.ReadUserInput()
+	} else {
+		ui.PrintMessage(fmt.Sprintf("👤: %s\n", c.prompt), ui.MessageTypeInfo)
+	}
+
+	if c.prompt == "/exit" {
+		return nil
+	}
+
+	c.handleChat(client, systemMessage, c.prompt)
+
+	return nil
+}
+
+func (c *InteractiveCmd) handleChat(client *openai.Client, systemMessage string, prompt string) {
+	chatInstance := chat.NewChat(client, systemMessage, c.printMessageChunk)
+	conversation := chatInstance.BeginConversation(prompt)
+
+	for {
+		conversation.WaitMyTurn()
+		ui.PrintMessage("👤: ", ui.MessageTypeInfo)
+
+		userMessage := ui.ReadUserInput()
+
+		if userMessage == "/exit" {
+			break
+		}
+
+		conversation.Reply(userMessage)
+	}
+}
+
+func (c *InteractiveCmd) printMessageChunk(chunk *chat.ConversationChunk) {
+	if chunk.IsInitialChunk {
+		ui.PrintMessage("🤖: ", ui.MessageTypeInfo)
+		return
+	}
+
+	if chunk.IsErrorChunk {
+		ui.PrintMessage(chunk.Content, ui.MessageTypeError)
+	}
+
+	if chunk.IsFinalChunk {
+		ui.PrintMessage("\n", ui.MessageTypeInfo)
+	}
+
+	ui.PrintMessage(chunk.Content, ui.MessageTypeInfo)
+}
+
+func (c *InteractiveCmd) gatherAndPrintContext() ([]filetree.File, string, error) {
+	// gatherAndPrintContext gathers file context based on provided options and prints it out.
+	files, rootNode, err := c.gatherContext()
+	if err != nil {
+		return nil, "", err
+	}
+
+	for _, file := range files {
+		printLargeFileWarning(file)
+	}
+
+	fileTree := filetree.GenerateFileTree(rootNode, "", true)
+
+	ui.PrintMessage("The following files will be used as context:\n", ui.MessageTypeInfo)
+	ui.PrintMessage(fileTree, ui.MessageTypeInfo)
+
+	return files, fileTree, nil
+}
+
+func (c *InteractiveCmd) gatherContext() ([]filetree.File, *filetree.FileNode, error) {
+	var excludeMatchers []pathmatcher.PathMatcher
+
+	// add exclude flag to excludeMatchers
+	if c.chatOptions.ExcludePattern != "" {
+		excludeMatcher, err := pathmatcher.NewRegexPathMatcher(c.chatOptions.ExcludePattern)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating exclude matcher: %w", err)
+		}
+
+		excludeMatchers = append(excludeMatchers, excludeMatcher)
+	}
+
+	excludeMatchersFromConfig, err := excludeMatchersFromConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	excludeMatchers = append(excludeMatchers, excludeMatchersFromConfig...)
+
+	excludeMatcher := pathmatcher.NewCompoundPathMatcher(excludeMatchers...)
+
+	includeMatcher, err := pathmatcher.NewRegexPathMatcher(c.chatOptions.IncludePattern)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating include matcher: %w", err)
+	}
+
+	files, rootNode, err := filetree.GatherFiles(&filetree.FileGatherOptions{
+		IncludeMatcher: includeMatcher,
+		ExcludeMatcher: excludeMatcher,
+		PathScopes:     c.chatOptions.Paths,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error gathering files: %w", err)
+	}
+
+	return files, rootNode, nil
+}

--- a/internal/cmd/noninteractive.go
+++ b/internal/cmd/noninteractive.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/intility/cwc/pkg/chat"
+	"github.com/intility/cwc/pkg/ui"
+)
+
+type NonInteractiveCmd struct {
+	prompt       string
+	templateName string
+	templateVars map[string]string
+}
+
+func NewNonInteractiveCmd(args []string, templateName string, templateVars map[string]string) *NonInteractiveCmd {
+	prompt := determinePrompt(args, templateName)
+	return &NonInteractiveCmd{prompt: prompt, templateName: templateName, templateVars: templateVars}
+}
+
+func (c *NonInteractiveCmd) Run() error {
+	client, err := newClientFromConfig()
+	if err != nil {
+		return fmt.Errorf("error creating client: %w", err)
+	}
+
+	systemCtx, err := c.readContextFromStdIn()
+	if err != nil {
+		return fmt.Errorf("error reading context from stdin: %w", err)
+	}
+
+	systemMessage, err := createSystemMessage(systemCtx, c.templateName, c.templateVars)
+	if err != nil {
+		return fmt.Errorf("error creating system message: %w", err)
+	}
+
+	chatInstance := chat.NewChat(client, systemMessage, c.printChunk)
+	conversation := chatInstance.BeginConversation(c.prompt)
+
+	conversation.WaitMyTurn()
+
+	return nil
+}
+
+func (c *NonInteractiveCmd) readContextFromStdIn() (string, error) {
+	inputBytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("error reading from stdin: %w", err)
+	}
+
+	return string(inputBytes), nil
+}
+
+func (c *NonInteractiveCmd) printChunk(chunk *chat.ConversationChunk) {
+	ui.PrintMessage(chunk.Content, ui.MessageTypeInfo)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/intility/cwc/pkg/errors"
 	"github.com/sashabaranov/go-openai"
 	"gopkg.in/yaml.v3"
+
+	"github.com/intility/cwc/pkg/errors"
 )
 
 const (

--- a/pkg/templates/yamlFileTemplateLocator.go
+++ b/pkg/templates/yamlFileTemplateLocator.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/intility/cwc/pkg/errors"
 	"gopkg.in/yaml.v3"
+
+	"github.com/intility/cwc/pkg/errors"
 )
 
 type YamlFileTemplateLocator struct {


### PR DESCRIPTION
Both interactive and non-interactive commands now
lives as separate structs inside internal/cmd.

This change reduces the complexity of the cobra
entry point and pave the way to introduce tests.

Additional changes:
renamed the gci prefix for internal imports from
emilkje/cwc to intility/cwc to properly format the imports.