### PR TITLE
feat: implement configurable API key storage

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/intility/cwc/pkg/errors"
 	"github.com/sashabaranov/go-openai"
 	"gopkg.in/yaml.v3"
-
-	"github.com/intility/cwc/pkg/errors"
 )
 
 const (
@@ -116,8 +115,8 @@ func SaveConfig(config *Config) error {
 	if err != nil {
 		return fmt.Errorf("error marshalling config data: %w", err)
 	}
-
-	err = storeAPIKeyInKeyring(config.APIKey())
+	apiKeyStorage := ResolveAPIKeyStorage()
+	err = apiKeyStorage.StoreAPIKey(config.APIKey())
 
 	if err != nil {
 		return err
@@ -159,8 +158,8 @@ func LoadConfig() (*Config, error) {
 			"please run `cwc login` to create a new config file.",
 		}}
 	}
-
-	apiKey, err := getAPIKeyFromKeyring()
+	apiKeyStorage := ResolveAPIKeyStorage()
+	apiKey, err := apiKeyStorage.GetAPIKey()
 	if err != nil {
 		return nil, errors.ConfigValidationError{Errors: []string{
 			err.Error(),
@@ -185,8 +184,8 @@ func ClearConfig() error {
 	if err != nil {
 		return fmt.Errorf("error removing config file: %w", err)
 	}
-
-	err = clearAPIKeyInKeyring()
+	apiKeyStorage := ResolveAPIKeyStorage()
+	err = apiKeyStorage.ClearAPIKey()
 	if err != nil {
 		return err
 	}

--- a/pkg/config/keyring.go
+++ b/pkg/config/keyring.go
@@ -2,33 +2,42 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"os/user"
+	"path/filepath"
 
 	"github.com/zalando/go-keyring"
 )
 
-func getAPIKeyFromKeyring() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("error getting current user: %w", err)
-	}
-
-	apiKey, err := keyring.Get(serviceName, usr.Username)
-	if err != nil {
-		return "", fmt.Errorf("error getting API key from keyring: %w", err)
-	}
-
-	return apiKey, nil
+type APIKeyStorage interface {
+	StoreAPIKey(key string) error
+	GetAPIKey() (string, error)
+	ClearAPIKey() error
 }
 
-func storeAPIKeyInKeyring(apiKey string) error {
+type KeyringAPIKeyStorage struct {
+	Servicename string
+}
+
+type FileAPIKeyStorage struct {
+	Filepath string
+}
+
+func isWSL() bool {
+	if _, exists := os.LookupEnv("WSL_DISTRO_NAME"); exists {
+		return true
+	}
+	return false
+}
+
+func (fs *KeyringAPIKeyStorage) StoreAPIKey(key string) error {
 	usr, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("error getting current user: %w", err)
 	}
 
 	username := usr.Username
-	err = keyring.Set(serviceName, username, apiKey)
+	err = keyring.Set(serviceName, username, key)
 
 	if err != nil {
 		return fmt.Errorf("error storing API key in keyring: %w", err)
@@ -37,7 +46,7 @@ func storeAPIKeyInKeyring(apiKey string) error {
 	return nil
 }
 
-func clearAPIKeyInKeyring() error {
+func (fs *KeyringAPIKeyStorage) ClearAPIKey() error {
 	usr, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("error getting current user: %w", err)
@@ -51,4 +60,65 @@ func clearAPIKeyInKeyring() error {
 	}
 
 	return nil
+}
+
+func (fs *KeyringAPIKeyStorage) GetAPIKey() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("error getting current user: %w", err)
+	}
+
+	apiKey, err := keyring.Get(serviceName, usr.Username)
+	if err != nil {
+		return "", fmt.Errorf("error getting API key from keyring: %w", err)
+	}
+
+	return apiKey, nil
+}
+
+func (fs *FileAPIKeyStorage) StoreAPIKey(key string) error {
+
+	if err := os.MkdirAll(filepath.Dir(fs.Filepath), 0700); err != nil {
+		return fmt.Errorf("error creating directories for file storage: %w", err)
+	}
+
+	err := os.WriteFile(fs.Filepath, []byte(key), 0600)
+	if err != nil {
+		return fmt.Errorf("error storing API key in file: %w", err)
+	}
+
+	return nil
+}
+
+func (fs *FileAPIKeyStorage) GetAPIKey() (string, error) {
+
+	data, err := os.ReadFile(fs.Filepath)
+	if os.IsNotExist(err) {
+		return "", nil // Return an empty string if the file does not exist
+	} else if err != nil {
+		return "", fmt.Errorf("error reading API key from file: %w", err)
+	}
+	return string(data), nil
+}
+
+func (fs *FileAPIKeyStorage) ClearAPIKey() error {
+	err := os.Remove(fs.Filepath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error removing API key from file: %w", err)
+	}
+
+	return nil
+}
+
+func ResolveAPIKeyStorage() APIKeyStorage {
+	if isWSL() {
+		usr, err := user.Current()
+		if err != nil {
+			return nil
+		}
+		homeDir := usr.HomeDir
+		apiKeyStoragePath := homeDir + "/.cwc/apikeystore"
+		return &FileAPIKeyStorage{Filepath: apiKeyStoragePath}
+	}
+	return &KeyringAPIKeyStorage{Servicename: serviceName}
 }

--- a/pkg/config/keyring.go
+++ b/pkg/config/keyring.go
@@ -75,12 +75,16 @@ func (fs *KeyringAPIKeyStorage) GetAPIKey() (string, error) {
 }
 
 func (fs *FileAPIKeyStorage) StoreAPIKey(key string) error {
-	var readWrite os.FileMode = 0o600
-	if err := os.MkdirAll(filepath.Dir(fs.Filepath), readWrite); err != nil {
+	var (
+		dirFileMode os.FileMode = 0o700
+		keyFileMode os.FileMode = 0o600
+	)
+
+	if err := os.MkdirAll(filepath.Dir(fs.Filepath), dirFileMode); err != nil {
 		return fmt.Errorf("error creating directories for file storage: %w", err)
 	}
 
-	err := os.WriteFile(fs.Filepath, []byte(key), readWrite)
+	err := os.WriteFile(fs.Filepath, []byte(key), keyFileMode)
 	if err != nil {
 		return fmt.Errorf("error storing API key in file: %w", err)
 	}


### PR DESCRIPTION
Introduce an APIKeyStorage interface with two concrete implementations: KeyringAPIKeyStorage and FileAPIKeyStorage.

The FileAPIKeyStorage implementation is first of all intended for WSL2 environments where keyring does not work that well, so temporarly storing to the file-system is the most user-friendly option.

The ResolveAPIKeyStorage function resolves which storage mechanism to use. If the system is WSL2, automatically use FileAPIKeyStorage.

Refactor config package to align with the new storage mechanism.