### PR TITLE
Feat add support for openai compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ The result output from cwc can also be piped to other commands as well. This exa
 
 ```sh
 # generate a commit message for current changes
-PROMPT="please write me a conventional commit for these changes"
-git diff HEAD | cwc $PROMPT | git commit -e --file -
+CWC_PROMPT="please write me a conventional commit for these changes"
+git diff HEAD | cwc $CWC_PROMPT | git commit -e --file -
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -81,10 +81,21 @@ After installing Chat With Code, you're just a few steps away from a conversatio
 
          ```sh
          cwc login \
+           --provider "azure" \
            --api-key=$API_KEY \
            --endpoint "https://your-endpoint.openai.azure.com/" \
            --deployment-name "gpt-4-turbo"
          ```
+
+         ```sh
+         # openai (compatible)
+         cwc login \
+           --provider "openai" \
+           --api-key=$API_KEY \
+           --endpoint "http://localhost:11434" \
+           --api-version "v1" \
+           --model "codellama"
+         ```     
 
    > **Security Notice**: Never input your API key directly into the command-line arguments to prevent potential exposure in shell history and process listings. The API key is securely stored in your personal keyring.
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,6 +20,46 @@ var (
 	apiVersionFlag      string //nolint:gochecknoglobals
 )
 
+func promptUserForConfig(ui cwcui.UI) { //nolint: varnamelen
+	if providerFlag == "" {
+		ui.PrintMessage("Enter Provider name (azure,openai): ", cwcui.MessageTypeInfo)
+		providerFlag = config.SanitizeInput(ui.ReadUserInput())
+	}
+
+	if apiKeyFlag == "" {
+		ui.PrintMessage("Enter the OpenAI API Key: ", cwcui.MessageTypeInfo)
+		apiKeyFlag = config.SanitizeInput(ui.ReadUserInput())
+	}
+
+	if endpointFlag == "" {
+		ui.PrintMessage("Enter the OpenAI API Endpoint: ", cwcui.MessageTypeInfo)
+		endpointFlag = config.SanitizeInput(ui.ReadUserInput())
+	}
+
+	if providerFlag == "azure" {
+		if modelDeploymentFlag == "" {
+			ui.PrintMessage("Enter the Azure OpenAI Model Deployment: ", cwcui.MessageTypeInfo)
+			modelDeploymentFlag = config.SanitizeInput(ui.ReadUserInput())
+		}
+
+		if apiVersionFlag == "" {
+			apiVersionFlag = config.APIVersion
+		}
+	}
+
+	if providerFlag == "openai" {
+		if modelFlag == "" {
+			ui.PrintMessage("Enter the Model name: ", cwcui.MessageTypeInfo)
+			modelFlag = config.SanitizeInput(ui.ReadUserInput())
+		}
+
+		if apiVersionFlag == "" {
+			ui.PrintMessage("Enter the API Version: ", cwcui.MessageTypeInfo)
+			apiVersionFlag = config.SanitizeInput(ui.ReadUserInput())
+		}
+	}
+}
+
 func createLoginCmd() *cobra.Command {
 	ui := cwcui.NewUI() //nolint:varnamelen
 	cmd := &cobra.Command{
@@ -30,43 +70,16 @@ func createLoginCmd() *cobra.Command {
 			"Your credentials will be stored securely in your keyring and will never be exposed on the file system directly.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prompt for other required authentication details (apiKey, endpoint, version, and deployment)
-			if providerFlag == "" {
-				ui.PrintMessage("Enter Provider name (azure,openai): ", cwcui.MessageTypeInfo)
-				providerFlag = config.SanitizeInput(ui.ReadUserInput())
-			}
+			promptUserForConfig(ui)
 
-			if apiKeyFlag == "" {
-				ui.PrintMessage("Enter the OpenAI API Key: ", cwcui.MessageTypeInfo)
-				apiKeyFlag = config.SanitizeInput(ui.ReadUserInput())
-			}
+			cfg := config.NewConfig(config.NewConfigParams{
+				Provider:        providerFlag,
+				Endpoint:        endpointFlag,
+				APIVersion:      apiVersionFlag,
+				ModelDeployment: modelDeploymentFlag,
+				Model:           modelFlag,
+			})
 
-			if endpointFlag == "" {
-				ui.PrintMessage("Enter the OpenAI API Endpoint: ", cwcui.MessageTypeInfo)
-				endpointFlag = config.SanitizeInput(ui.ReadUserInput())
-			}
-
-			if providerFlag == "azure" {
-				if modelDeploymentFlag == "" {
-					ui.PrintMessage("Enter the Azure OpenAI Model Deployment: ", cwcui.MessageTypeInfo)
-					modelDeploymentFlag = config.SanitizeInput(ui.ReadUserInput())
-				}
-				if apiVersionFlag == "" {
-					apiVersionFlag = config.ApiVersion
-				}
-			}
-
-			if providerFlag == "openai" {
-				if modelFlag == "" {
-					ui.PrintMessage("Enter the Model name: ", cwcui.MessageTypeInfo)
-					modelFlag = config.SanitizeInput(ui.ReadUserInput())
-				}
-				if apiVersionFlag == "" {
-					ui.PrintMessage("Enter the API Version: ", cwcui.MessageTypeInfo)
-					apiVersionFlag = config.SanitizeInput(ui.ReadUserInput())
-				}
-			}
-
-			cfg := config.NewConfig(providerFlag, endpointFlag, apiVersionFlag, modelDeploymentFlag, modelFlag)
 			cfg.SetAPIKey(apiKeyFlag)
 
 			provider := config.NewDefaultProvider()
@@ -89,11 +102,13 @@ func createLoginCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&providerFlag, "provider", "p", "", "Provider name. Supported providers: "+strings.Join(config.SupportedProviders, " "))
+	cmd.Flags().StringVarP(&providerFlag, "provider", "p", "",
+		"Provider name. Supported providers: "+strings.Join(config.SupportedProviders, " "))
 	cmd.Flags().StringVarP(&modelFlag, "model", "m", "", "OpenAI (compatible) Model")
 	cmd.Flags().StringVarP(&apiKeyFlag, "api-key", "k", "", "API Key")
 	cmd.Flags().StringVarP(&endpointFlag, "endpoint", "e", "", "API Endpoint")
 	cmd.Flags().StringVarP(&apiVersionFlag, "api-version", "v", "", "API Version")
 	cmd.Flags().StringVarP(&modelDeploymentFlag, "model-deployment", "d", "", "Azure OpenAI Model Deployment")
+
 	return cmd
 }

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/intility/cwc/pkg/config"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -99,8 +100,15 @@ func (c *Conversation) Reply(message string) {
 }
 
 func (c *Conversation) processMessages(ctx context.Context) error {
+	provider := config.NewDefaultProvider()
+
+	cfg, err := provider.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get config from default provider: %w", err)
+	}
+
 	req := openai.ChatCompletionRequest{
-		Model:    openai.GPT4TurboPreview,
+		Model:    cfg.Model,
 		Messages: c.messages,
 		Stream:   true,
 	}

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/intility/cwc/pkg/config"
 	"github.com/sashabaranov/go-openai"
+
+	"github.com/intility/cwc/pkg/config"
 )
 
 type Chat struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,7 @@ import (
 const (
 	configFileName        = "cwc.yaml" // The name of the config file we want to save
 	configFilePermissions = 0o600      // The permissions we want to set on the config file
-	apiVersion            = "2024-02-01"
+	ApiVersion            = "2024-02-01"
 )
 
 // SanitizeInput trims whitespaces and newlines from a string.
@@ -18,23 +18,34 @@ func SanitizeInput(input string) string {
 }
 
 type Config struct {
+	Provider        string `yaml:"provider"`
 	Endpoint        string `yaml:"endpoint"`
 	ModelDeployment string `yaml:"modelDeployment"`
+	Model           string `yaml:"model"`
 	ExcludeGitDir   bool   `yaml:"excludeGitDir"`
 	UseGitignore    bool   `yaml:"useGitignore"`
+	ApiVersion      string `yaml:"apiVersion"`
 	// Keep APIKey unexported to avoid accidental exposure
 	apiKey string
 }
 
 // NewConfig creates a new Config object.
-func NewConfig(endpoint, modelDeployment string) *Config {
+func NewConfig(provider, endpoint, apiVersion, modelDeployment, model string) *Config {
 	return &Config{
+		Provider:        provider,
 		Endpoint:        endpoint,
+		ApiVersion:      apiVersion,
 		ModelDeployment: modelDeployment,
+		Model:           model,
 		ExcludeGitDir:   true,
 		UseGitignore:    true,
 		apiKey:          "",
 	}
+}
+
+var SupportedProviders = []string{
+	"azure",
+	"openai",
 }
 
 // SetAPIKey sets the confidential field apiKey.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,13 @@ import (
 const (
 	configFileName        = "cwc.yaml" // The name of the config file we want to save
 	configFilePermissions = 0o600      // The permissions we want to set on the config file
-	ApiVersion            = "2024-02-01"
+	APIVersion            = "2024-02-01"
 )
+
+var SupportedProviders = []string{ //nolint:gochecknoglobals
+	"azure",
+	"openai",
+}
 
 // SanitizeInput trims whitespaces and newlines from a string.
 func SanitizeInput(input string) string {
@@ -24,28 +29,31 @@ type Config struct {
 	Model           string `yaml:"model"`
 	ExcludeGitDir   bool   `yaml:"excludeGitDir"`
 	UseGitignore    bool   `yaml:"useGitignore"`
-	ApiVersion      string `yaml:"apiVersion"`
+	APIVersion      string `yaml:"apiVersion"`
 	// Keep APIKey unexported to avoid accidental exposure
 	apiKey string
 }
 
+type NewConfigParams struct {
+	Provider        string
+	Endpoint        string
+	APIVersion      string
+	ModelDeployment string
+	Model           string
+}
+
 // NewConfig creates a new Config object.
-func NewConfig(provider, endpoint, apiVersion, modelDeployment, model string) *Config {
+func NewConfig(params NewConfigParams) *Config {
 	return &Config{
-		Provider:        provider,
-		Endpoint:        endpoint,
-		ApiVersion:      apiVersion,
-		ModelDeployment: modelDeployment,
-		Model:           model,
+		Provider:        params.Provider,
+		Endpoint:        params.Endpoint,
+		APIVersion:      params.APIVersion,
+		ModelDeployment: params.ModelDeployment,
+		Model:           params.Model,
 		ExcludeGitDir:   true,
 		UseGitignore:    true,
 		apiKey:          "",
 	}
-}
-
-var SupportedProviders = []string{
-	"azure",
-	"openai",
 }
 
 // SetAPIKey sets the confidential field apiKey.

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -186,10 +186,17 @@ func (c *DefaultProvider) NewFromConfigFile() (openai.ClientConfig, error) {
 		return openai.ClientConfig{}, err
 	}
 
-	config := openai.DefaultAzureConfig(cfg.APIKey(), cfg.Endpoint)
-	config.APIVersion = apiVersion
-	config.AzureModelMapperFunc = func(model string) string {
-		return cfg.ModelDeployment
+	var config openai.ClientConfig
+	if cfg.Provider == "azure" {
+		config = openai.DefaultAzureConfig(cfg.APIKey(), cfg.Endpoint)
+		config.APIVersion = cfg.ApiVersion
+		config.AzureModelMapperFunc = func(model string) string {
+			return cfg.ModelDeployment
+		}
+	}
+	if cfg.Provider == "openai" {
+		config = openai.DefaultConfig(cfg.apiKey)
+		config.BaseURL = cfg.Endpoint + "/" + cfg.ApiVersion
 	}
 
 	return config, nil

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -19,6 +19,11 @@ type Provider interface {
 	ClearConfig() error
 }
 
+const (
+	providerAzure  = "azure"
+	providerOpenai = "openai"
+)
+
 type FileManager interface {
 	Read(path string) ([]byte, error)
 	Write(path string, content []byte, perm os.FileMode) error
@@ -187,16 +192,17 @@ func (c *DefaultProvider) NewFromConfigFile() (openai.ClientConfig, error) {
 	}
 
 	var config openai.ClientConfig
-	if cfg.Provider == "azure" {
+	if cfg.Provider == providerAzure {
 		config = openai.DefaultAzureConfig(cfg.APIKey(), cfg.Endpoint)
-		config.APIVersion = cfg.ApiVersion
+		config.APIVersion = cfg.APIVersion
 		config.AzureModelMapperFunc = func(model string) string {
 			return cfg.ModelDeployment
 		}
 	}
+
 	if cfg.Provider == "openai" {
 		config = openai.DefaultConfig(cfg.apiKey)
-		config.BaseURL = cfg.Endpoint + "/" + cfg.ApiVersion
+		config.BaseURL = cfg.Endpoint + "/" + cfg.APIVersion
 	}
 
 	return config, nil

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -1,6 +1,11 @@
 package config
 
-import "github.com/intility/cwc/pkg/errors"
+import (
+	"strings"
+
+	"github.com/intility/cwc/pkg/errors"
+	"github.com/sashabaranov/go-openai"
+)
 
 func DefaultValidator(cfg *Config) error {
 	var validationErrors []string
@@ -13,8 +18,25 @@ func DefaultValidator(cfg *Config) error {
 		validationErrors = append(validationErrors, "endpoint must be provided and not be empty")
 	}
 
-	if cfg.ModelDeployment == "" {
-		validationErrors = append(validationErrors, "modelDeployment must be provided and not be empty")
+	if cfg.Provider == "" {
+		cfg.Provider = "azure"
+	}
+
+	switch cfg.Provider {
+	case "azure":
+		if cfg.ModelDeployment == "" {
+			cfg.ModelDeployment = openai.GPT4TurboPreview
+		}
+	case "openai":
+		if cfg.Model == "" {
+			validationErrors = append(validationErrors, "model must be provided and not be empty")
+		}
+	default:
+		validationErrors = append(validationErrors, "provider not supported. supported providers:"+strings.Join(SupportedProviders, " "))
+	}
+
+	if cfg.ApiVersion == "" {
+		validationErrors = append(validationErrors, "apiversion must be provided and not be empty")
 	}
 
 	if len(validationErrors) > 0 {

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -3,45 +3,73 @@ package config
 import (
 	"strings"
 
-	"github.com/intility/cwc/pkg/errors"
 	"github.com/sashabaranov/go-openai"
+
+	"github.com/intility/cwc/pkg/errors"
 )
 
 func DefaultValidator(cfg *Config) error {
 	var validationErrors []string
 
-	if cfg.APIKey() == "" {
-		validationErrors = append(validationErrors, "apiKey must be provided and not be empty")
-	}
-
-	if cfg.Endpoint == "" {
-		validationErrors = append(validationErrors, "endpoint must be provided and not be empty")
-	}
-
-	if cfg.Provider == "" {
-		cfg.Provider = "azure"
-	}
-
-	switch cfg.Provider {
-	case "azure":
-		if cfg.ModelDeployment == "" {
-			cfg.ModelDeployment = openai.GPT4TurboPreview
-		}
-	case "openai":
-		if cfg.Model == "" {
-			validationErrors = append(validationErrors, "model must be provided and not be empty")
-		}
-	default:
-		validationErrors = append(validationErrors, "provider not supported. supported providers:"+strings.Join(SupportedProviders, " "))
-	}
-
-	if cfg.ApiVersion == "" {
-		validationErrors = append(validationErrors, "apiversion must be provided and not be empty")
-	}
+	validationErrors = append(validationErrors, validateAPIKey(cfg)...)
+	validationErrors = append(validationErrors, validateEndpoint(cfg)...)
+	validationErrors = append(validationErrors, validateProvider(cfg)...)
+	validationErrors = append(validationErrors, validateAPIVersion(cfg)...)
 
 	if len(validationErrors) > 0 {
 		return &errors.ConfigValidationError{Errors: validationErrors}
 	}
 
 	return nil
+}
+
+func validateAPIKey(cfg *Config) []string {
+	var errors []string
+	if cfg.APIKey() == "" {
+		errors = append(errors, "apiKey must be provided and not be empty")
+	}
+
+	return errors
+}
+
+func validateEndpoint(cfg *Config) []string {
+	var errors []string
+	if cfg.Endpoint == "" {
+		errors = append(errors, "endpoint must be provided and not be empty")
+	}
+
+	return errors
+}
+
+func validateProvider(cfg *Config) []string {
+	var errors []string
+
+	if cfg.Provider == "" {
+		cfg.Provider = providerAzure
+	}
+
+	switch cfg.Provider {
+	case providerAzure:
+		if cfg.ModelDeployment == "" {
+			cfg.ModelDeployment = openai.GPT4TurboPreview
+		}
+	case providerOpenai:
+		if cfg.Model == "" {
+			errors = append(errors, "model must be provided and not be empty")
+		}
+	default:
+		errors = append(errors,
+			"provider not supported. supported providers:"+strings.Join(SupportedProviders, " "))
+	}
+
+	return errors
+}
+
+func validateAPIVersion(cfg *Config) []string {
+	var errors []string
+	if cfg.APIVersion == "" {
+		errors = append(errors, "apiversion must be provided and not be empty")
+	}
+
+	return errors
 }


### PR DESCRIPTION
Adds support for openai compatible llm providers. Resolves #11 

## Changes
- `cmd/login.go` login flow now supports specifying provider, and gives different options based on the provider
- Adjusted `pkg/chat/chat.go` to fetch and use the selected LLM model from configuration. 
     - **Note**: A bit unsure if how I fetch the config here is optimal. Please review.
- `pkg/config/config.go` added provider, model, and API version as a configurable parameters.
- Implemented provider-specific logic in `pkg/config/provider.go` for setting up client configurations.
- Updated `DefaultValidator` in `pkg/config/validator.go` to support the new provider field.  Set a default model deployment and provider if it has not been set in configuration to avoid breaking changes
- docs: Updated `README.md` with an alternative login example, and updated azure login example (add provider attribute)

## Testing: 

Tested with OpenAI API and Ollama. 

Please verify non-breaking changes to azure openai deployment configs.